### PR TITLE
Improve scan diagnostics and surface UI warnings

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,12 +14,16 @@ import os
 import sys
 import argparse
 import json
+import logging
 from datetime import timedelta
 
 # --- make sure we can import the package when running as a script ---
 ROOT = os.path.dirname(os.path.abspath(__file__))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 try:
     # Absolute imports from the package
@@ -121,7 +125,7 @@ def main():
         state_all = load_json(STATE_FILE, {})
         state_key = f"nvd:{hash_for_cpes(cpes)}"
 
-        results, updated_entry = run_scan(
+        results, updated_entry, issues = run_scan(
             cpes=cpes,
             state_all=state_all,
             state_key=state_key,
@@ -132,6 +136,10 @@ def main():
             no_rejected=True,
             kev_only=False,
         )
+
+        if issues:
+            for issue in issues:
+                logger.error("NVD request failed for %s: %s", issue.get("cpe"), issue.get("message"))
 
         # Save state
         if updated_entry.get("per_cpe"):

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from app import scan
+
+
+@pytest.fixture
+def sample_cpe():
+    return "cpe:2.3:a:vendor:product:1:*:*:*:*:*:*:*"
+
+
+def test_run_scan_collects_issues(monkeypatch, sample_cpe):
+    """run_scan should surface recoverable errors as issue entries."""
+
+    def fake_fetch(*args, **kwargs):
+        raise RuntimeError("network boom")
+
+    monkeypatch.setattr(scan, "fetch_for_cpe", fake_fetch)
+
+    results, updated, issues = scan.run_scan(
+        cpes=[sample_cpe],
+        state_all={},
+        state_key="nvd:test",
+        session=object(),
+        insecure=False,
+        api_key=None,
+        since=datetime.now(timezone.utc),
+    )
+
+    assert results == []
+    assert isinstance(updated, dict)
+    assert issues and issues[0]["cpe"] == sample_cpe
+    assert "network boom" in issues[0]["message"]


### PR DESCRIPTION
## Summary
- capture and propagate recoverable NVD fetch failures with logging and structured issue data
- harden Flask API error handling and expose scan issues to both bootstrap payloads and run endpoint responses
- update the frontend to surface server-reported issues, improve fetch error messaging, and extend run button feedback
- add a regression test verifying that `run_scan` reports issues when a CPE request fails

## Testing
- pytest
- flake8
- bandit -r app

------
https://chatgpt.com/codex/tasks/task_e_68d3df50fb00832d90aa31e59e00b74e